### PR TITLE
feat: add genre management UI

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import PublicRoute from './components/PublicRoute';
 import ProtectedRoute from './components/ProtectedRoute';
 import { AuthProvider } from './context/AuthContext';
 import SignupScreen from './components/SignupScreen';
+import GenresScreen from './components/GenresScreen';
 
 function App() {
   return (
@@ -36,6 +37,14 @@ function App() {
               element={
                 <ProtectedRoute>
                   <Dashboard />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/genres"
+              element={
+                <ProtectedRoute>
+                  <GenresScreen />
                 </ProtectedRoute>
               }
             />

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -38,20 +38,23 @@ const Dashboard = () => {
 
       {/* Navigation Menu */}
       <nav className="py-4">
-        <ul className="flex space-x-8">
-          <li>
-            <button className="flex items-center px-4 py-2 text-gray-700 hover:text-green-600 hover:bg-green-50 rounded-md transition-colors font-medium">
-              <span className="mr-2">🎤</span>
-              Géneros
-            </button>
-          </li>
-          <li>
-            <button className="flex items-center px-4 py-2 text-gray-700 hover:text-green-600 hover:bg-green-50 rounded-md transition-colors font-medium">
-              <span className="mr-2">🎹</span>
-              Artistas
-            </button>
-          </li>
-        </ul>
+          <ul className="flex space-x-8">
+            <li>
+              <button
+                className="flex items-center px-4 py-2 text-gray-700 hover:text-green-600 hover:bg-green-50 rounded-md transition-colors font-medium"
+                onClick={() => navigate('/genres')}
+              >
+                <span className="mr-2">🎤</span>
+                Géneros
+              </button>
+            </li>
+            <li>
+              <button className="flex items-center px-4 py-2 text-gray-700 hover:text-green-600 hover:bg-green-50 rounded-md transition-colors font-medium">
+                <span className="mr-2">🎹</span>
+                Artistas
+              </button>
+            </li>
+          </ul>
       </nav>
 
       {/* Contenido Principal */}

--- a/frontend/src/components/GenresScreen.jsx
+++ b/frontend/src/components/GenresScreen.jsx
@@ -1,0 +1,149 @@
+import { useEffect, useState } from 'react';
+import { genreService } from '../services';
+
+const GenresScreen = () => {
+  const [genres, setGenres] = useState([]);
+  const [name, setName] = useState('');
+  const [editingId, setEditingId] = useState(null);
+  const [editingName, setEditingName] = useState('');
+  const [error, setError] = useState('');
+
+  const load = async () => {
+    try {
+      const data = await genreService.getAll();
+      setGenres(data);
+    } catch (e) {
+      setError(e.message);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleCreate = async (e) => {
+    e.preventDefault();
+    try {
+      await genreService.create({ name });
+      setName('');
+      await load();
+    } catch (e) {
+      setError(e.message);
+    }
+  };
+
+  const startEdit = (id, currentName) => {
+    setEditingId(id);
+    setEditingName(currentName);
+  };
+
+  const handleUpdate = async (id) => {
+    try {
+      await genreService.update(id, { name: editingName });
+      setEditingId(null);
+      setEditingName('');
+      await load();
+    } catch (e) {
+      setError(e.message);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('¿Eliminar género?')) return;
+    try {
+      await genreService.remove(id);
+      await load();
+    } catch (e) {
+      setError(e.message);
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-4">
+      <h2 className="text-2xl font-bold mb-4">Géneros</h2>
+      {error && (
+        <div className="bg-red-100 text-red-800 p-2 mb-4 rounded">
+          {error}
+        </div>
+      )}
+      <form onSubmit={handleCreate} className="flex mb-4">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Nuevo género"
+          className="flex-1 border p-2 mr-2 rounded"
+        />
+        <button
+          type="submit"
+          className="bg-green-500 text-white px-4 py-2 rounded"
+        >
+          Agregar
+        </button>
+      </form>
+      <table className="w-full border">
+        <thead>
+          <tr>
+            <th className="border px-2 py-1 text-left">Nombre</th>
+            <th className="border px-2 py-1">Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          {genres.map((g) => (
+            <tr key={g.id}>
+              <td className="border px-2 py-1">
+                {editingId === g.id ? (
+                  <input
+                    className="border p-1 w-full rounded"
+                    value={editingName}
+                    onChange={(e) => setEditingName(e.target.value)}
+                  />
+                ) : (
+                  g.name
+                )}
+              </td>
+              <td className="border px-2 py-1 text-center">
+                {editingId === g.id ? (
+                  <>
+                    <button
+                      type="button"
+                      className="bg-blue-500 text-white px-2 py-1 mr-2 rounded"
+                      onClick={() => handleUpdate(g.id)}
+                    >
+                      Guardar
+                    </button>
+                    <button
+                      type="button"
+                      className="bg-gray-300 px-2 py-1 rounded"
+                      onClick={() => setEditingId(null)}
+                    >
+                      Cancelar
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      className="bg-blue-500 text-white px-2 py-1 mr-2 rounded"
+                      onClick={() => startEdit(g.id, g.name)}
+                    >
+                      Editar
+                    </button>
+                    <button
+                      type="button"
+                      className="bg-red-500 text-white px-2 py-1 rounded"
+                      onClick={() => handleDelete(g.id)}
+                    >
+                      Eliminar
+                    </button>
+                  </>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default GenresScreen;

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,9 +1,5 @@
-import {
-    createContext,
-    useContext,
-    useState,
-    useEffect
-} from "react";
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useState, useEffect } from "react";
 
 import { authService } from "../services";
 
@@ -38,8 +34,8 @@ export const AuthProvider = ({ children }) => {
     }, []);
 
     const login = async (email, password) => {
+        setLoading(true);
         try {
-            setLoading(true);
             await authService.login(email, password);
             const currentUser = authService.getCurrentUser();
             if (currentUser) {
@@ -47,20 +43,16 @@ export const AuthProvider = ({ children }) => {
                 setIsAuthenticated(true);
             }
             return true;
-        } catch (error) {
-            throw error;
         } finally {
             setLoading(false);
         }
     };
 
     const register = async (name, lastname, email, password) => {
+        setLoading(true);
         try {
-            setLoading(true);
             const result = await authService.register(name, lastname, email, password);
             return result;
-        } catch (error) {
-            throw error;
         } finally {
             setLoading(false);
         }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,13 +1,6 @@
 // Configuración base de la API
 const API_BASE_URL = 'https://ecos-api-production.up.railway.app';
 
-// Configuración base para las peticiones
-const apiConfig = {
-  headers: {
-    'Content-Type': 'application/json',
-  },
-};
-
 // Función helper para manejar respuestas de la API
 const handleResponse = async (response) => {
   if (!response.ok) {

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -40,7 +40,9 @@ export const authService = {
       try {
         const err = await response.json();
         if (err?.detail || err?.message) message = err.detail || err.message;
-      } catch {}
+      } catch {
+        // ignore JSON parse errors
+      }
       if (response.status === 401) {
         throw new Error("Credenciales inválidas. Verifica tu email y contraseña.");
       }

--- a/frontend/src/services/genreService.js
+++ b/frontend/src/services/genreService.js
@@ -1,0 +1,40 @@
+import { API_BASE_URL, handleResponse } from './api.js';
+import { authService } from './authService.js';
+
+const authHeaders = () => {
+  const token = authService.getToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
+
+const getAll = async () => {
+  const res = await fetch(`${API_BASE_URL}/genres`);
+  return handleResponse(res);
+};
+
+const create = async (genre) => {
+  const res = await fetch(`${API_BASE_URL}/genres`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify(genre),
+  });
+  return handleResponse(res);
+};
+
+const update = async (id, genre) => {
+  const res = await fetch(`${API_BASE_URL}/genres/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify(genre),
+  });
+  return handleResponse(res);
+};
+
+const remove = async (id) => {
+  const res = await fetch(`${API_BASE_URL}/genres/${id}`, {
+    method: 'DELETE',
+    headers: { ...authHeaders() },
+  });
+  return handleResponse(res);
+};
+
+export const genreService = { getAll, create, update, remove };

--- a/frontend/src/services/index.js
+++ b/frontend/src/services/index.js
@@ -1,2 +1,3 @@
 export { authService } from './authService.js'
 export { API_BASE_URL } from './api.js'
+export { genreService } from './genreService.js'


### PR DESCRIPTION
## Summary
- add service helpers for genre CRUD operations
- create screen to list, add, edit and remove genres
- wire genres page into routing and dashboard

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e9d44182c8327b94f97605c9af40e