### PR TITLE
feat: associate artists with multiple genres

### DIFF
--- a/backend/controllers/artist.py
+++ b/backend/controllers/artist.py
@@ -72,7 +72,15 @@ async def list_artists():
         for artist in results:
             artist["id"] = str(artist.pop("_id"))
             artist["albums"] = [str(aid) for aid in artist.get("albums", [])]
-            artist["genre_ids"] = [str(gid) for gid in artist.get("genre", [])]
+            raw_genres = artist.get("genre", [])
+            if isinstance(raw_genres, list):
+                artist["genre_ids"] = [str(gid) for gid in raw_genres]
+            elif raw_genres:
+                # handle legacy data where genre was stored as a single string
+                artist["genre_ids"] = [str(raw_genres)]
+            else:
+                artist["genre_ids"] = []
+
             artist["genre"] = artist.get("genres", [])  # list of genre docs
             if (
                 isinstance(artist["genre"], list)

--- a/backend/models/artist.py
+++ b/backend/models/artist.py
@@ -40,11 +40,10 @@ class ArtistResponse(BaseModel):
     id: str
 
 
-# Modelo de salida ya enriquecido con nombres de géneros (para list_artists y detalles)
+# Modelo de salida para artistas
 class ArtistOut(BaseModel):
     id: str
     name: str
-    genre: List[str]  # genre names returned by the lookup
     genre_ids: List[str] = []
     country: str
     albums: List[str] = []

--- a/backend/models/artist.py
+++ b/backend/models/artist.py
@@ -4,9 +4,15 @@ from typing import Optional, List
 
 class ArtistCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=100, description="Name of the artist")
-    genre: List[str] = Field(..., description="List of genre names associated with the artist")
-    country: str = Field(..., min_length=2, max_length=100, description="Country of origin")
-    albums: Optional[List[str]] = Field(default_factory=list, description="List of album IDs for this artist")
+    genre: List[str] = Field(
+        ..., description="List of genre IDs associated with the artist"
+    )
+    country: str = Field(
+        ..., min_length=2, max_length=100, description="Country of origin"
+    )
+    albums: Optional[List[str]] = Field(
+        default_factory=list, description="List of album IDs for this artist"
+    )
 
     @validator("name")
     def name_must_be_alpha(cls, v):
@@ -23,7 +29,7 @@ class ArtistCreate(BaseModel):
 
 class ArtistUpdate(BaseModel):
     name: Optional[str] = None
-    genre: Optional[List[str]] = None  # nombres de género
+    genre: Optional[List[str]] = None  # genre IDs
     country: Optional[str] = None
     albums: Optional[List[str]] = None
 
@@ -38,6 +44,7 @@ class ArtistResponse(BaseModel):
 class ArtistOut(BaseModel):
     id: str
     name: str
-    genre: List[str]  # género por nombre, gracias al lookup
+    genre: List[str]  # genre names returned by the lookup
+    genre_ids: List[str] = []
     country: str
     albums: List[str] = []

--- a/backend/pipelines/artist_pipeline.py
+++ b/backend/pipelines/artist_pipeline.py
@@ -1,20 +1,11 @@
 def artist_with_genres_pipeline():
     return [
         {
-            "$lookup": {
-                "from": "genre",
-                "localField": "genre",
-                "foreignField": "_id",
-                "as": "genres"
-            }
-        },
-        {
             "$project": {
                 "name": 1,
                 "country": 1,
                 "albums": 1,
-                "genres.name": 1,
-                "genre": 1  # opcional, si quieres conservar los ObjectId
+                "genre": 1,
             }
         }
     ]

--- a/frontend/src/components/ArtistScreen.jsx
+++ b/frontend/src/components/ArtistScreen.jsx
@@ -65,6 +65,14 @@ const ArtistScreen = () => {
     }
   };
 
+  const genreMap = Object.fromEntries(genres.map((g) => [g.id, g.name]));
+
+  const getGenreNames = (artist) =>
+    (artist.genre_ids || [])
+      .map((id) => genreMap[id])
+      .filter(Boolean)
+      .join(', ');
+
   return (
     <div className="p-4">
       <h2 className="text-2xl font-bold mb-4">Gestión de Artistas</h2>
@@ -123,7 +131,7 @@ const ArtistScreen = () => {
             <tr key={a.id} className="text-center">
               <td className="border p-2">{a.name}</td>
               <td className="border p-2">{a.country}</td>
-              <td className="border p-2">{Array.isArray(a.genre) ? a.genre.join(', ') : ''}</td>
+              <td className="border p-2">{getGenreNames(a)}</td>
               <td className="border p-2 space-x-2">
                 <button
                   onClick={() => handleEdit(a)}

--- a/frontend/src/components/ArtistScreen.jsx
+++ b/frontend/src/components/ArtistScreen.jsx
@@ -52,7 +52,7 @@ const ArtistScreen = () => {
 
   const handleEdit = (artist) => {
     setEditingId(artist.id);
-    setForm({ name: artist.name, country: artist.country, genre: artist.genre });
+    setForm({ name: artist.name, country: artist.country, genre: artist.genre_ids });
   };
 
   const handleDelete = async (id) => {
@@ -95,11 +95,11 @@ const ArtistScreen = () => {
           onChange={handleChange}
           className="border p-2 w-full"
         >
-          {genres.map((g) => (
-            <option key={g.id} value={g.name}>
-              {g.name}
-            </option>
-          ))}
+            {genres.map((g) => (
+              <option key={g.id} value={g.id}>
+                {g.name}
+              </option>
+            ))}
         </select>
         <button
           type="submit"

--- a/frontend/src/services/artistService.js
+++ b/frontend/src/services/artistService.js
@@ -7,7 +7,7 @@ const getArtists = async () => {
 };
 
 const createArtist = async (artist) => {
-  const response = await fetch(`${API_BASE_URL}/artists`, {
+  const response = await fetch(`${API_BASE_URL}/artists/`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- store genre references by ID on artists
- expose genre IDs and names on artist listings
- allow selecting genres when creating or editing artists on the frontend

## Testing
- `pytest -q` (fails: Error en la conexion a MongoDB La conexion a la BD Fallo)
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689eacbab8bc8327889aae13e0de0e7c